### PR TITLE
Remove Sentry shutdown delay

### DIFF
--- a/src/sentry.rs
+++ b/src/sentry.rs
@@ -8,7 +8,7 @@ pub fn init_sentry(dsn: Option<String>) -> Option<ClientInitGuard> {
         sentry::ClientOptions {
             release: sentry::release_name!(),
             traces_sample_rate: 0.1,
-            shutdown_timeout: Duration::from_secs(2),
+            shutdown_timeout: Duration::ZERO,
             ..Default::default()
         },
     ));


### PR DESCRIPTION
## Summary
- remove Sentry shutdown timeout to eliminate exit delay

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6898acbb25b48328939a9fae1046a9d0