### PR TITLE
Add Redis caching and default image fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ MAX_IMAGE_SIDE=1600
 # Postgres
 DATABASE_URL=postgres://user:pass@localhost:5432/onlihub
 
+# Redis
+REDIS_URL=redis://127.0.0.1/
+
 # Swagger (вкл/выкл)
 SWAGGER_ENABLED=true
 SWAGGER_TITLE=Onlihub Media CDN

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +320,17 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -484,6 +501,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
+ "redis",
  "regex",
  "reqwest",
  "serde",
@@ -530,6 +548,20 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "const-oid"
@@ -875,6 +907,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +994,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1919,6 +1967,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2237,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "redis"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.4.10",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -2586,6 +2678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2745,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "socket2"
@@ -3155,6 +3263,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ mime = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 rand = "0.8"
 regex = "1"
+redis = { version = "0.24", features = ["tokio-comp", "connection-manager"] }
 
 # БД
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "macros"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+use redis::{aio::ConnectionManager, AsyncCommands, Client};
+use tokio::sync::Mutex;
+
+#[derive(Clone)]
+pub struct Cache {
+    conn: Arc<Mutex<ConnectionManager>>,
+}
+
+impl Cache {
+    pub async fn new(redis_url: &str) -> redis::RedisResult<Self> {
+        let client = Client::open(redis_url)?;
+        let manager = ConnectionManager::new(client).await?;
+        Ok(Self { conn: Arc::new(Mutex::new(manager)) })
+    }
+
+    pub async fn get(&self, key: &str) -> redis::RedisResult<Option<Vec<u8>>> {
+        let mut conn = self.conn.lock().await;
+        conn.get(key).await
+    }
+
+    pub async fn insert_with_ttl(&self, key: &str, value: &[u8], ttl_secs: usize, max: usize) -> redis::RedisResult<()> {
+        let mut conn = self.conn.lock().await;
+        let list_key = "image_cache_keys";
+        conn.set_ex::<_, _, ()>(key, value, ttl_secs as u64).await?;
+        conn.lpush::<_, _, ()>(list_key, key).await?;
+        let len: usize = conn.llen(list_key).await?;
+        if len > max {
+            let to_remove: Vec<String> = conn.lrange(list_key, max as isize, -1).await?;
+            for old in to_remove {
+                let _: () = conn.del(old).await?;
+            }
+            let _: () = conn.ltrim(list_key, 0, (max as isize) - 1).await?;
+        }
+        Ok(())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ pub struct Settings {
     pub no_image_file: String,  // relative to media_base_dir, как в Python
     pub max_image_side: u32,
     pub database_url: String,
+    pub redis_url: String,
     pub swagger_enabled: bool,
     pub swagger_title: String,
     pub swagger_version: String,
@@ -29,6 +30,8 @@ impl Settings {
         let database_url = env::var("DATABASE_URL")
             .unwrap_or_else(|_| "postgres://user:pass@localhost:5432/onlihub".into());
 
+        let redis_url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1/".into());
+
         let swagger_enabled = env::var("SWAGGER_ENABLED")
             .map(|s| s == "true" || s == "1")
             .unwrap_or(true);
@@ -46,6 +49,7 @@ impl Settings {
             no_image_file,
             max_image_side,
             database_url,
+            redis_url,
             swagger_enabled,
             swagger_title,
             swagger_version,


### PR DESCRIPTION
## Summary
- serve no-image placeholder whenever original image or GUID is invalid
- cache resized images in Redis with 15‑minute TTL and 500 item limit
- wire Redis cache through configuration and app startup

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689a314cca9c8328be5ca3c5d57a9825