### PR TITLE
feat: add redis cache configuration and use swagger vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,11 @@ MAX_IMAGE_SIDE=1600
 DATABASE_URL=postgres://user:pass@localhost:5432/onlihub
 
 # Redis
-REDIS_URL=redis://127.0.0.1/
+USE_CACHE=false
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_PASSWORD=
 
 # Swagger (вкл/выкл)
 SWAGGER_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ cdn-rs/
 | `NO_IMAGE_FILE` | Имя файла-заглушки внутри `MEDIA_BASE_DIR` | `no-image-01.jpg` |
 | `MAX_IMAGE_SIDE` | Лимит на сторону при ресайзе | `1600` |
 | `DATABASE_URL` | Строка подключения к Postgres | — (обязательна) |
+| `USE_CACHE` | Включить Redis-кэш (`true`/`false`) | `false` |
+| `REDIS_HOST` | Хост Redis | `127.0.0.1` |
+| `REDIS_PORT` | Порт Redis | `6379` |
+| `REDIS_DB` | Номер базы Redis | `0` |
+| `REDIS_PASSWORD` | Пароль Redis | _пусто_ |
 | `SWAGGER_ENABLED` | Включить Swagger UI (`true`/`false`) | `true` |
 | `SWAGGER_TITLE` | Заголовок для Swagger | `Onlihub Media CDN` |
 | `SWAGGER_VERSION` | Версия API в Swagger | `1.0.0` |

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,36 +1,54 @@
-use std::sync::Arc;
 use redis::{aio::ConnectionManager, AsyncCommands, Client};
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[derive(Clone)]
 pub struct Cache {
-    conn: Arc<Mutex<ConnectionManager>>,
+    conn: Option<Arc<Mutex<ConnectionManager>>>,
 }
 
 impl Cache {
-    pub async fn new(redis_url: &str) -> redis::RedisResult<Self> {
-        let client = Client::open(redis_url)?;
-        let manager = ConnectionManager::new(client).await?;
-        Ok(Self { conn: Arc::new(Mutex::new(manager)) })
+    pub async fn new(redis_url: Option<&str>) -> redis::RedisResult<Self> {
+        if let Some(url) = redis_url {
+            let client = Client::open(url)?;
+            let manager = ConnectionManager::new(client).await?;
+            Ok(Self {
+                conn: Some(Arc::new(Mutex::new(manager))),
+            })
+        } else {
+            Ok(Self { conn: None })
+        }
     }
 
     pub async fn get(&self, key: &str) -> redis::RedisResult<Option<Vec<u8>>> {
-        let mut conn = self.conn.lock().await;
-        conn.get(key).await
+        if let Some(conn) = &self.conn {
+            let mut conn = conn.lock().await;
+            conn.get(key).await
+        } else {
+            Ok(None)
+        }
     }
 
-    pub async fn insert_with_ttl(&self, key: &str, value: &[u8], ttl_secs: usize, max: usize) -> redis::RedisResult<()> {
-        let mut conn = self.conn.lock().await;
-        let list_key = "image_cache_keys";
-        conn.set_ex::<_, _, ()>(key, value, ttl_secs as u64).await?;
-        conn.lpush::<_, _, ()>(list_key, key).await?;
-        let len: usize = conn.llen(list_key).await?;
-        if len > max {
-            let to_remove: Vec<String> = conn.lrange(list_key, max as isize, -1).await?;
-            for old in to_remove {
-                let _: () = conn.del(old).await?;
+    pub async fn insert_with_ttl(
+        &self,
+        key: &str,
+        value: &[u8],
+        ttl_secs: usize,
+        max: usize,
+    ) -> redis::RedisResult<()> {
+        if let Some(conn) = &self.conn {
+            let mut conn = conn.lock().await;
+            let list_key = "image_cache_keys";
+            conn.set_ex::<_, _, ()>(key, value, ttl_secs as u64).await?;
+            conn.lpush::<_, _, ()>(list_key, key).await?;
+            let len: usize = conn.llen(list_key).await?;
+            if len > max {
+                let to_remove: Vec<String> = conn.lrange(list_key, max as isize, -1).await?;
+                for old in to_remove {
+                    let _: () = conn.del(old).await?;
+                }
+                let _: () = conn.ltrim(list_key, 0, (max as isize) - 1).await?;
             }
-            let _: () = conn.ltrim(list_key, 0, (max as isize) - 1).await?;
         }
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,11 @@ pub struct Settings {
     pub no_image_file: String,  // relative to media_base_dir, как в Python
     pub max_image_side: u32,
     pub database_url: String,
-    pub redis_url: String,
+    pub use_cache: bool,
+    pub redis_host: String,
+    pub redis_port: u16,
+    pub redis_db: u8,
+    pub redis_password: String,
     pub swagger_enabled: bool,
     pub swagger_title: String,
     pub swagger_version: String,
@@ -30,13 +34,27 @@ impl Settings {
         let database_url = env::var("DATABASE_URL")
             .unwrap_or_else(|_| "postgres://user:pass@localhost:5432/onlihub".into());
 
-        let redis_url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1/".into());
+        let use_cache = env::var("USE_CACHE")
+            .map(|s| s == "true" || s == "1")
+            .unwrap_or(false);
+
+        let redis_host = env::var("REDIS_HOST").unwrap_or_else(|_| "127.0.0.1".into());
+        let redis_port = env::var("REDIS_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6379);
+        let redis_db = env::var("REDIS_DB")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let redis_password = env::var("REDIS_PASSWORD").unwrap_or_default();
 
         let swagger_enabled = env::var("SWAGGER_ENABLED")
             .map(|s| s == "true" || s == "1")
             .unwrap_or(true);
 
-        let swagger_title = env::var("SWAGGER_TITLE").unwrap_or_else(|_| "Onlihub Media CDN".into());
+        let swagger_title =
+            env::var("SWAGGER_TITLE").unwrap_or_else(|_| "Onlihub Media CDN".into());
         let swagger_version = env::var("SWAGGER_VERSION").unwrap_or_else(|_| "1.0.0".into());
 
         let use_proxies = env::var("USE_PROXIES")
@@ -49,7 +67,11 @@ impl Settings {
             no_image_file,
             max_image_side,
             database_url,
-            redis_url,
+            use_cache,
+            redis_host,
+            redis_port,
+            redis_db,
+            redis_password,
             swagger_enabled,
             swagger_title,
             swagger_version,
@@ -59,5 +81,19 @@ impl Settings {
 
     pub fn no_image_full_path(&self) -> String {
         format!("{}{}", self.media_base_dir, self.no_image_file)
+    }
+
+    pub fn redis_url(&self) -> String {
+        if self.redis_password.is_empty() {
+            format!(
+                "redis://{}:{}/{}",
+                self.redis_host, self.redis_port, self.redis_db
+            )
+        } else {
+            format!(
+                "redis://:{}@{}:{}/{}",
+                self.redis_password, self.redis_host, self.redis_port, self.redis_db
+            )
+        }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -9,6 +9,7 @@ pub struct Db {
 }
 
 #[derive(sqlx::FromRow, Debug, Clone)]
+#[allow(dead_code)]
 pub struct ImageRow {
     pub id: i64,
     pub guid: Uuid,
@@ -31,11 +32,11 @@ impl Db {
         let rec: (i64,) = sqlx::query_as(
             "insert into images (guid, status, status_date) values ($1, $2, now()) returning id",
         )
-            .bind(guid)
-            .bind(status)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(|e| ApiError::Db(e.to_string()))?;
+        .bind(guid)
+        .bind(status)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| ApiError::Db(e.to_string()))?;
         Ok(rec.0)
     }
 
@@ -49,14 +50,15 @@ impl Db {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub async fn get_image_by_guid(&self, guid: Uuid) -> Result<Option<ImageRow>, ApiError> {
         let rec = sqlx::query_as::<_, ImageRow>(
             "select id, guid, link_o, status, status_date from images where guid = $1",
         )
-            .bind(guid)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| ApiError::Db(e.to_string()))?;
+        .bind(guid)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| ApiError::Db(e.to_string()))?;
         Ok(rec)
     }
 
@@ -71,6 +73,7 @@ impl Db {
     }
 
     /// get or create by link_o; returns (id, guid)
+    #[allow(dead_code)]
     pub async fn get_or_create_by_link(&self, link: &str) -> Result<(i64, Uuid), ApiError> {
         if let Some((id, guid)) =
             sqlx::query_as::<_, (i64, Uuid)>("select id, guid from images where link_o = $1")

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
+    #[allow(dead_code)]
     #[error("not found")]
     NotFound,
     #[error("bad request: {0}")]


### PR DESCRIPTION
## Summary
- add granular Redis env variables with a cache toggle
- apply Swagger title/version settings to OpenAPI
- silence unused code warnings

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_689a3bd9b49883289999ac8b02cd585f