### PR TITLE
Ensure atomic image writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "dashmap",
  "dotenvy",
  "fast_image_resize",
  "futures-util",
@@ -658,6 +659,19 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ rand = "0.8"
 regex = "1"
 redis = { version = "0.24", features = ["tokio-comp", "connection-manager"] }
 
+dashmap = "5"
+
 # БД
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "macros"] }
 


### PR DESCRIPTION
## Summary
- write images atomically and guard concurrent variant creation
- validate downloads by content-type/length
- depend on dashmap for per-variant locks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689b1a5386ec832890187eea40f16e13