### PR TITLE
Fix lock map memory leak in imaging

### DIFF
--- a/src/imaging.rs
+++ b/src/imaging.rs
@@ -52,8 +52,11 @@ where
         .entry(key.to_string())
         .or_insert_with(|| Arc::new(Mutex::new(())))
         .clone();
-    let _g = lock.lock().await;
-    fut.await
+    let guard = lock.lock().await;
+    let result = fut.await;
+    drop(guard);
+    VARIANT_LOCKS.remove(key);
+    result
 }
 
 fn target_and_foreground(


### PR DESCRIPTION
## Summary
- drop variant locks after use to avoid unbounded growth

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689efc9bdb10832893c970769c63dfc2