### PR TITLE
Guard variant locks and semaphore permits to prevent leaks

### DIFF
--- a/src/routes/cdn.rs
+++ b/src/routes/cdn.rs
@@ -108,7 +108,9 @@ async fn stream_original(
         .map_err(|e| ApiError::Io(e.to_string()))?;
     tokio::spawn(async move {
         while let Some(chunk) = rx.recv().await {
-            let _ = file.write_all(&chunk).await;
+            if file.write_all(&chunk).await.is_err() {
+                break;
+            }
         }
     });
     let stream = resp.bytes_stream().then(move |item| {


### PR DESCRIPTION
## Summary
- ensure variant lock entries are always removed using a drop guard
- use `Arc<Semaphore>` and move semaphore permits into blocking tasks to release even if tasks panic
- break file writer loop on errors when streaming original images

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f09960954832886f89c787114b262