### PR TITLE
Reduce memory footprint in image processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "fast_image_resize",
  "futures-util",
  "image",
+ "libc",
  "mime",
  "num_cpus",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 num_cpus = "1.17.0"
+libc = "0.2"


### PR DESCRIPTION
## Summary
- add `release_memory` using `libc::malloc_trim` and invoke it during cleanup and after image processing
- drop variant-lock clone to allow removing unused lock entries
- depend on `libc`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f2f0ac9948328bda2472127566304